### PR TITLE
KeyboardioScanner.h: Fix a warning

### DIFF
--- a/KeyboardioScanner.h
+++ b/KeyboardioScanner.h
@@ -14,10 +14,10 @@ struct cRGB {
 #define LEDS_PER_HAND 32
 #define LED_BYTES_PER_BANK sizeof(cRGB)  * LEDS_PER_HAND/LED_BANKS
 
-typedef union LEDData_t {
+typedef union {
     cRGB leds[LEDS_PER_HAND];
     byte bytes[LED_BANKS][LED_BYTES_PER_BANK];
-};
+} LEDData_t;
 
 
 // Same datastructure as on the other side


### PR DESCRIPTION
When compiled with warnings enabled, g++ complains about the typedef being ignored, because it does not have a name. To remedy this, add a name.

Previously, the name was the name of the struct, not that of the type.
