### PR TITLE
Update for standardized format of cRGB

### DIFF
--- a/KeyboardioScanner.h
+++ b/KeyboardioScanner.h
@@ -3,22 +3,17 @@
 #include <Arduino.h>
 #include "wire-protocol-constants.h"
 
-struct cRGB {
-  uint8_t b;
-  uint8_t g;
-  uint8_t r;
-};
+#include "Kaleidoscope-Hardware.h"
 
 #define LED_BANKS 4
 
 #define LEDS_PER_HAND 32
-#define LED_BYTES_PER_BANK sizeof(cRGB)  * LEDS_PER_HAND/LED_BANKS
+#define LED_BYTES_PER_BANK sizeof(cBGR) * LEDS_PER_HAND/LED_BANKS
 
 typedef union {
-  cRGB leds[LEDS_PER_HAND];
+  cBGR leds[LEDS_PER_HAND];
   byte bytes[LED_BANKS][LED_BYTES_PER_BANK];
 } LEDData_t;
-
 
 // Same datastructure as on the other side
 typedef union {


### PR DESCRIPTION
This is pull request # 3/4 unifying the definition of `cRGB` across hardwares.  The other three pull requests are against `keyboardio/Kaleidoscope`, `keyboardio/Kaleidoscope-Hardware-Model01`, and `shortcutgg/Kaleidoscope-Hardware-Shortcut`.  None of the four pull requests will build without the others, unfortunately.

The rationale for these pull requests is as follows.  First, a unified definition of `cRGB` is intuitive and elegant.  As part of the core hardware API, it also makes sense to define `cRGB` in the Kaleidoscope core.  

Second, this brings down a major barrier to implementing an actual abstract hardware base class (which is planned as a followup series of pull requests against these same repos; however, the issue of unifying `cRGB` seemed separate enough to warrant separate pull requests with their own discussion).  In fact, the unified definition of `cRGB` is declared by itself in a file called “Kaleidoscope-Hardware.h”, which is very forward-looking as eventually it will simply be declared as part of the abstract hardware base class.

Third, although it may seem at first glance that these pull requests may harm performance in terms of code size and/or execution time, this is actually not the case.  The additional function calls are inlined, and the resulting code generally just takes struct-copy operations that were already happening and changes them to copy struct members to different places.  The code is more verbose, but should compile down to the same number of operations to my knowledge.  To back up these assertions, we compare results of compiling a few sketches before and after these four pull requests are applied.  For the Model 01, we build the two sketches in `keyboardio/Kaleidoscope/examples`; the unified `cRGB` definition results in the exact same code size for `AppSwitcher`, and actually a 2-byte *improvement* for `Kaleidoscope`.  For the Shortcut, we build the sketch in `shortcutgg/Kaleidoscope-Hardware-Shortcut/examples`; again we end up with the exact same code size with or without these four pull requests.  I would imagine these results also indicate execution time hasn’t changed.