### PR TITLE
Removed unused key_t structure

### DIFF
--- a/KeyboardioScanner.h
+++ b/KeyboardioScanner.h
@@ -20,19 +20,6 @@ typedef union {
 } LEDData_t;
 
 
-// Same datastructure as on the other side
-typedef union {
-  struct {
-    uint8_t row: 2,
-            col: 3,
-            keyState: 1,
-            keyEventsWaiting: 1,
-            eventReported: 1;
-  };
-  uint8_t val;
-} key_t;
-
-
 typedef union {
   uint8_t rows[4];
   uint32_t all;


### PR DESCRIPTION
This union is used on the keyscanner, but not by anything on this side.

Maybe there are some plans to use this in the future, but from the history it looks vestigial.