### PR TITLE
fix implicit-fallthrough warning

### DIFF
--- a/twi.c
+++ b/twi.c
@@ -444,6 +444,7 @@ ISR(TWI_vect) {
   case TW_MR_DATA_ACK: // data received, ack sent
     // put byte into buffer
     twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
+    /* intentionally fall through */
   case TW_MR_SLA_ACK:  // address sent, ack received
     // ack if more bytes are expected, otherwise nack
     if (twi_masterBufferIndex < twi_masterBufferLength) {


### PR DESCRIPTION
On Archlinux (when using archlinux arduino packages) there is a warning during `make flash`:
```
…/hardware/keyboardio/avr/libraries/KeyboardioScanner/twi.c: In function '__vector_36':
…/hardware/keyboardio/avr/libraries/KeyboardioScanner/twi.c:446:47: warning: this statement may fall through [-Wimplicit-fallthrough=]
     twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
                                               ^
…/hardware/keyboardio/avr/libraries/KeyboardioScanner/twi.c:447:3: note: here
   case TW_MR_SLA_ACK:  // address sent, ack received
   ^~~~
```
As it's explained [here](https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/) the warning can be disable with the comment `/* FALLTHRU */`.

**Beware**, I don't understand this part of code. I added the FALLTHRU comment because I **guessed** the fallthrough was intentional !

Please don't merge this if you don't know if the fallthrough is intentional or not.