### PR TITLE
Allow the hardware specification to supply cRGB

### DIFF
--- a/KeyboardioScanner.h
+++ b/KeyboardioScanner.h
@@ -25,11 +25,7 @@
 #include <Arduino.h>
 #include "wire-protocol-constants.h"
 
-struct cRGB {
-  uint8_t b;
-  uint8_t g;
-  uint8_t r;
-};
+#include KALEIDOSCOPE_HARDWARE_SPEC_H
 
 #define LED_BANKS 4
 
@@ -40,7 +36,6 @@ typedef union {
   cRGB leds[LEDS_PER_HAND];
   byte bytes[LED_BANKS][LED_BYTES_PER_BANK];
 } LEDData_t;
-
 
 typedef union {
   uint8_t rows[4];


### PR DESCRIPTION
This is one of a set of PRs that intent to fix Kaleidoscope virtual builds.

Changes were made to the following repos

* Kaleidoscope
* Kaleidoscope-HIDAdaptor-KeyboardioHID
* Kaleidoscope-Hardware-Virtual
* KeyboardioScanner
* Kaleidoscope-Bundle-Keyboardio (see https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio/pull/18)

All PRs must be merged together for everything to work.

See the commit messages of the individual commits for further information of what has been changed.