### PR TITLE
Enable cRGB/CRGB to be pre-defined when including KeyboardioScanner.h

### DIFF
--- a/KeyboardioScanner.h
+++ b/KeyboardioScanner.h
@@ -25,11 +25,16 @@
 #include <Arduino.h>
 #include "wire-protocol-constants.h"
 
+// We allow cRGB/CRGB to be defined already when this is included.
+//
+#ifndef CRGB
 struct cRGB {
   uint8_t b;
   uint8_t g;
   uint8_t r;
 };
+#define CRGB(r,g,b) (cRGB){b, g, r}
+#endif
 
 #define LED_BANKS 4
 


### PR DESCRIPTION
This PR is a part of https://github.com/keyboardio/Kaleidoscope-Bundle-Keyboardio/pull/18

This change is necessary as cRGB is possibly typedefed in the same scope and
typedefs collide with struct names. After dividing up keyboardio hardware
headers in a specification and an implementation header, cRGB is
possibly already typedefed in the specification header.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>