### PR TITLE
twi.c: Adjust a comment to help GCC

### DIFF
--- a/twi.c
+++ b/twi.c
@@ -530,7 +530,7 @@ ISR(TWI_vect) {
       twi_txBufferLength = 1;
       twi_txBuffer[0] = 0x00;
     }
-  // transmit first byte from buffer, fall
+  // transmit first byte from buffer, fall through
   case TW_ST_DATA_ACK: // byte sent, ack returned
     // copy data to output register
     TWDR = twi_txBuffer[twi_txBufferIndex++];


### PR DESCRIPTION
Adjust a comment that signals explicit fall through, to help GCC recognise it.

Depends on keyboardio/Kaleidoscope-Bundle-Keyboardio#34 to have any effect.